### PR TITLE
Added header icons for source/twitter/stackoverflow

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,4 +9,6 @@
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
+
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,9 +20,9 @@
           {% endif %}
         {% endfor %}
 
-        <a class="page-link" href="https://github.com/r2dbc" target="_blank">Source</a>
-        <a class="page-link" href="https://twitter.com/r2dbc" target="_blank">Twitter</a>
-        <a class="page-link" href="https://stackoverflow.com/questions/tagged/r2dbc" target="_blank">Questions</a>
+        <a class="page-link fab fa-github" href="https://github.com/r2dbc" target="_blank" title="Source"></a>
+        <a class="page-link fab fa-twitter" href="https://twitter.com/r2dbc" target="_blank" title="Twitter"></a>
+        <a class="page-link fab fa-stack-overflow" href="https://stackoverflow.com/questions/tagged/r2dbc" target="_blank" title="Questions on Stackoverflow"></a>
       </div>
     </nav>
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -42,6 +42,32 @@
         }
     }
 
+    a.fab {
+        font-size: $base-font-size * 1.5;
+        vertical-align: middle;
+        &:hover {
+            text-decoration: none;
+        }
+    }
+
+    .fa-twitter {
+        &:hover {
+            color: #00aced;
+        }
+    }
+
+    .fa-stack-overflow {
+        &:hover {
+            color: #f48024;
+        }
+    }
+
+    .fa-gitub {
+        &:hover {
+            color: #333;
+        }
+    }
+
     @include media-query($on-palm) {
         position: absolute;
         top: 9px;


### PR DESCRIPTION
Use icons to provide more space in the header area. Icon hover highlights the icon with its primary brand color.


<img width="619" alt="screenshot 2018-11-17 17 49 31" src="https://user-images.githubusercontent.com/1035015/48663481-3ed36900-ea91-11e8-8fd1-f2c9f096eb74.png">
