### PR TITLE
URL Cleanup

### DIFF
--- a/spec/1.0.0.M7/spec/html/index.html
+++ b/spec/1.0.0.M7/spec/html/index.html
@@ -181,7 +181,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-     <a href="http://www.apache.org/licenses/LICENSE-2.0" class="bare">http://www.apache.org/licenses/LICENSE-2.0</a>
+     <a href="https://www.apache.org/licenses/LICENSE-2.0" class="bare">https://www.apache.org/licenses/LICENSE-2.0</a>
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/spec/1.0.0.M7/spec/pdf/r2dbc-spec-1.0.0.M7.pdf
+++ b/spec/1.0.0.M7/spec/pdf/r2dbc-spec-1.0.0.M7.pdf
@@ -752,7 +752,7 @@ endobj
 << /Border [0 0 0]
 /A << /Type /Action
 /S /URI
-/URI (http://www.apache.org/licenses/LICENSE-2.0)
+/URI (https://www.apache.org/licenses/LICENSE-2.0)
 >>
 /Subtype /Link
 /Rect [86.74 464.885 207.74 475.885]
@@ -763,7 +763,7 @@ endobj
 << /Border [0 0 0]
 /A << /Type /Action
 /S /URI
-/URI (http://www.apache.org/licenses/LICENSE-2.0)
+/URI (https://www.apache.org/licenses/LICENSE-2.0)
 >>
 /Subtype /Link
 /Rect [207.74 464.885 207.74 475.885]
@@ -774,7 +774,7 @@ endobj
 << /Border [0 0 0]
 /A << /Type /Action
 /S /URI
-/URI (http://www.apache.org/licenses/LICENSE-2.0)
+/URI (https://www.apache.org/licenses/LICENSE-2.0)
 >>
 /Subtype /Link
 /Rect [207.74 464.885 257.24 475.885]
@@ -785,7 +785,7 @@ endobj
 << /Border [0 0 0]
 /A << /Type /Action
 /S /URI
-/URI (http://www.apache.org/licenses/LICENSE-2.0)
+/URI (https://www.apache.org/licenses/LICENSE-2.0)
 >>
 /Subtype /Link
 /Rect [257.24 464.885 257.24 475.885]
@@ -796,7 +796,7 @@ endobj
 << /Border [0 0 0]
 /A << /Type /Action
 /S /URI
-/URI (http://www.apache.org/licenses/LICENSE-2.0)
+/URI (https://www.apache.org/licenses/LICENSE-2.0)
 >>
 /Subtype /Link
 /Rect [257.24 464.885 317.74 475.885]


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 7 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).