### PR TITLE
URL Cleanup

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -34,7 +34,7 @@
 
     <p><span class="licence">R2DBC is licensed under the Apache Software License 2.</span></p>
 
-    <p>© 2018 <a href="/">R2DBC</a>, powered by <a href="http://pivotal.io/" class="pivotal" target="_blank">Pivotal</a> | <a href="https://www.pivotal.io/terms-of-use" target="_blank">Terms of Use</a> | <a href="https://www.pivotal.io/privacy-policy" target="_blank">Privacy</a> | <span id="teconsent"></span></p>
+    <p>© 2018 <a href="/">R2DBC</a>, powered by <a href="https://pivotal.io/" class="pivotal" target="_blank">Pivotal</a> | <a href="https://www.pivotal.io/terms-of-use" target="_blank">Terms of Use</a> | <a href="https://www.pivotal.io/privacy-policy" target="_blank">Privacy</a> | <span id="teconsent"></span></p>
 
   </div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,11 +1,11 @@
 ---
 layout: default
 ---
-<article class="post" itemscope itemtype="http://schema.org/BlogPosting">
+<article class="post" itemscope itemtype="https://schema.org/BlogPosting">
 
   <header class="post-header">
     <h1 class="post-title" itemprop="name headline">{{ page.title }}</h1>
-    <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}</p>
+    <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="https://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}</p>
   </header>
 
   <div class="post-content" itemprop="articleBody">

--- a/_posts/2018-10-10-welcome-to-jekyll.markdown
+++ b/_posts/2018-10-10-welcome-to-jekyll.markdown
@@ -20,6 +20,6 @@ print_hi('Tom')
 
 Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most out of Jekyll. File all bugs/feature requests at [Jekyll’s GitHub repo][jekyll-gh]. If you have questions, you can ask them on [Jekyll Talk][jekyll-talk].
 
-[jekyll-docs]: http://jekyllrb.com/docs/home
+[jekyll-docs]: https://jekyllrb.com/docs/home
 [jekyll-gh]:   https://github.com/jekyll/jekyll
 [jekyll-talk]: https://talk.jekyllrb.com/


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://pivotal.io/ with 1 occurrences migrated to:  
  https://pivotal.io/ ([https](https://pivotal.io/) result 200).
* [ ] http://schema.org/BlogPosting with 1 occurrences migrated to:  
  https://schema.org/BlogPosting ([https](https://schema.org/BlogPosting) result 200).
* [ ] http://schema.org/Person with 1 occurrences migrated to:  
  https://schema.org/Person ([https](https://schema.org/Person) result 200).
* [ ] http://jekyllrb.com/docs/home with 1 occurrences migrated to:  
  https://jekyllrb.com/docs/home ([https](https://jekyllrb.com/docs/home) result 301).