### PR TITLE
URL Cleanup

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -35,7 +35,7 @@
 
     <p><span class="licence">R2DBC is licensed under the Apache Software License 2.</span></p>
 
-    <p>© 2018 <a href="/">R2DBC</a>, powered by <a href="http://pivotal.io/" class="pivotal" target="_blank">Pivotal</a> | <a href="https://www.pivotal.io/terms-of-use" target="_blank">Terms of Use</a> | <a href="https://www.pivotal.io/privacy-policy" target="_blank">Privacy</a> | <span id="teconsent"></span></p>
+    <p>© 2018 <a href="/">R2DBC</a>, powered by <a href="https://pivotal.io/" class="pivotal" target="_blank">Pivotal</a> | <a href="https://www.pivotal.io/terms-of-use" target="_blank">Terms of Use</a> | <a href="https://www.pivotal.io/privacy-policy" target="_blank">Privacy</a> | <span id="teconsent"></span></p>
 
   </div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,11 +1,11 @@
 ---
 layout: default
 ---
-<article class="post" itemscope itemtype="http://schema.org/BlogPosting">
+<article class="post" itemscope itemtype="https://schema.org/BlogPosting">
 
   <header class="post-header">
     <h1 class="post-title" itemprop="name headline">{{ page.title }}</h1>
-    <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%Y-%-m-%-d" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}{% if page.tags.size > 0 %} • {{ page.tags | sort | join: ", " }} {% endif %}</p>
+    <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%Y-%-m-%-d" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="https://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}{% if page.tags.size > 0 %} • {{ page.tags | sort | join: ", " }} {% endif %}</p>
   </header>
 
   <div class="post-content" itemprop="articleBody">

--- a/spec/1.0.0.M7/api/allclasses-frame.html
+++ b/spec/1.0.0.M7/api/allclasses-frame.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/allclasses-noframe.html
+++ b/spec/1.0.0.M7/api/allclasses-noframe.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/constant-values.html
+++ b/spec/1.0.0.M7/api/constant-values.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/deprecated-list.html
+++ b/spec/1.0.0.M7/api/deprecated-list.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/help-doc.html
+++ b/spec/1.0.0.M7/api/help-doc.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/index-all.html
+++ b/spec/1.0.0.M7/api/index-all.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/index.html
+++ b/spec/1.0.0.M7/api/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "http://www.w3.org/TR/html4/frameset.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "https://www.w3.org/TR/html4/frameset.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/Batch.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/Batch.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/ColumnMetadata.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/ColumnMetadata.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/Connection.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/Connection.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/ConnectionFactories.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/ConnectionFactories.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/ConnectionFactory.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/ConnectionFactory.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/ConnectionFactoryMetadata.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/ConnectionFactoryMetadata.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/ConnectionFactoryOptions.Builder.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/ConnectionFactoryOptions.Builder.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/ConnectionFactoryOptions.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/ConnectionFactoryOptions.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/ConnectionFactoryProvider.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/ConnectionFactoryProvider.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/IsolationLevel.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/IsolationLevel.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/Nullability.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/Nullability.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/Option.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/Option.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/R2dbcException.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/R2dbcException.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/Result.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/Result.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/Row.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/Row.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/RowMetadata.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/RowMetadata.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/Statement.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/Statement.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/Wrapped.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/Wrapped.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Batch.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Batch.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/ColumnMetadata.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/ColumnMetadata.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Connection.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Connection.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/ConnectionFactories.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/ConnectionFactories.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/ConnectionFactory.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/ConnectionFactory.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/ConnectionFactoryMetadata.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/ConnectionFactoryMetadata.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/ConnectionFactoryOptions.Builder.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/ConnectionFactoryOptions.Builder.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/ConnectionFactoryOptions.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/ConnectionFactoryOptions.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/ConnectionFactoryProvider.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/ConnectionFactoryProvider.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/IsolationLevel.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/IsolationLevel.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Nullability.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Nullability.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Option.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Option.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/R2dbcException.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/R2dbcException.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Result.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Result.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Row.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Row.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/RowMetadata.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/RowMetadata.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Statement.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Statement.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Wrapped.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/class-use/Wrapped.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/package-frame.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/package-frame.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/package-summary.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/package-summary.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/package-tree.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/package-tree.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/io/r2dbc/spi/package-use.html
+++ b/spec/1.0.0.M7/api/io/r2dbc/spi/package-use.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/overview-tree.html
+++ b/spec/1.0.0.M7/api/overview-tree.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/api/serialized-form.html
+++ b/spec/1.0.0.M7/api/serialized-form.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <!-- NewPage -->
 <html lang="de">
 <head>

--- a/spec/1.0.0.M7/spec/html/asciidoctor.css
+++ b/spec/1.0.0.M7/spec/html/asciidoctor.css
@@ -1,4 +1,4 @@
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/spec/1.0.0.M7/spec/html/index.html
+++ b/spec/1.0.0.M7/spec/html/index.html
@@ -240,7 +240,7 @@ R2DBC targets primarily, but is not limited to, relational databases.
 It aims for a range of data sources whose query and statement interface is based on SQL (or a SQL-like dialect) and represent their data in a tabular form.</p>
 </div>
 <div class="paragraph">
-<p>A key difference between R2DBC and imperative data access SPIs is the deferred nature of execution. R2DBC is therefore based on <a href="http://www.reactive-streams.org/">Reactive Streams</a> to use the concept of <code>Publisher</code> and <code>Subscriber</code> to allow non-blocking backpressure-aware data access.</p>
+<p>A key difference between R2DBC and imperative data access SPIs is the deferred nature of execution. R2DBC is therefore based on <a href="https://www.reactive-streams.org/">Reactive Streams</a> to use the concept of <code>Publisher</code> and <code>Subscriber</code> to allow non-blocking backpressure-aware data access.</p>
 </div>
 </div>
 <div class="sect2">
@@ -288,7 +288,7 @@ We want to thank all <a href="https://github.com/r2dbc/r2dbc-spi/graphs/contribu
 <div class="sect2">
 <h3 id="introduction.following"><a class="anchor" href="#introduction.following"></a>1.5. Following Development</h3>
 <div class="paragraph">
-<p>For information on R2DBC source code repositories, nightly builds, and snapshot artifacts, see the <a href="http://r2dbc.io/resources/">R2DBC</a> homepage.
+<p>For information on R2DBC source code repositories, nightly builds, and snapshot artifacts, see the <a href="https://r2dbc.io/resources/">R2DBC</a> homepage.
 You can help make R2DBC best serve the needs of the community by interacting with developers through the community.
 To follow developer activity, look for the mailing list information on the R2DBC homepage.
 If you encounter a bug or want to suggest an improvement, please create a ticket on the R2DBC issue tracker.

--- a/spec/1.0.0.M7/spec/pdf/r2dbc-spec-1.0.0.M7.pdf
+++ b/spec/1.0.0.M7/spec/pdf/r2dbc-spec-1.0.0.M7.pdf
@@ -1465,7 +1465,7 @@ endobj
 << /Border [0 0 0]
 /A << /Type /Action
 /S /URI
-/URI (http://www.reactive-streams.org/)
+/URI (https://www.reactive-streams.org/)
 >>
 /Subtype /Link
 /Rect [263.0449 397.28 351.2635 411.56]
@@ -1950,7 +1950,7 @@ endobj
 << /Border [0 0 0]
 /A << /Type /Action
 /S /URI
-/URI (http://r2dbc.io/resources/)
+/URI (https://r2dbc.io/resources/)
 >>
 /Subtype /Link
 /Rect [48.24 707.22 81.9135 721.5]


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.w3.org/TR/html4/frameset.dtd (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/html4/frameset.dtd ([https](https://www.w3.org/TR/html4/frameset.dtd) result ReadTimeoutException).
* [ ] http://www.w3.org/TR/html4/loose.dtd (ReadTimeoutException) with 48 occurrences migrated to:  
  https://www.w3.org/TR/html4/loose.dtd ([https](https://www.w3.org/TR/html4/loose.dtd) result ReadTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://asciidoctor.org with 1 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* [ ] http://pivotal.io/ with 1 occurrences migrated to:  
  https://pivotal.io/ ([https](https://pivotal.io/) result 200).
* [ ] http://r2dbc.io/resources/ with 2 occurrences migrated to:  
  https://r2dbc.io/resources/ ([https](https://r2dbc.io/resources/) result 200).
* [ ] http://schema.org/BlogPosting with 1 occurrences migrated to:  
  https://schema.org/BlogPosting ([https](https://schema.org/BlogPosting) result 200).
* [ ] http://schema.org/Person with 1 occurrences migrated to:  
  https://schema.org/Person ([https](https://schema.org/Person) result 200).
* [ ] http://www.reactive-streams.org/ with 2 occurrences migrated to:  
  https://www.reactive-streams.org/ ([https](https://www.reactive-streams.org/) result 200).