### PR TITLE
Link to latest jOOQ version instead of fixed

### DIFF
--- a/z002-clients.md
+++ b/z002-clients.md
@@ -13,7 +13,7 @@ If you're eager to start using R2DBC to build an application, check out the [exi
 * [r2dbc-client](https://github.com/r2dbc/r2dbc-client) - client using pure Reactor (i.e. no Spring dependencies).
 * [spring-data-r2dbc](https://github.com/spring-projects/spring-data-r2dbc) - Spring Data client for R2DBC.
 * [Kotysa](https://github.com/ufoss-org/kotysa) - Typesafe and Co-routine-ready SQL engine using Kotlin.
-* [jOOQ](https://www.jooq.org/doc/3.13/manual/sql-execution/fetching/reactive-fetching/) - a fluent API for typesafe SQL query construction library.
+* [jOOQ](https://www.jooq.org/doc/latest/manual/sql-execution/fetching/reactive-fetching/) - a fluent API for typesafe SQL query construction library.
 * [Testcontainers](https://www.testcontainers.org/modules/databases/r2dbc/) - support to connect and bootstrap a database in a Testcontainer.
 * [Komapper](https://github.com/komapper/komapper) - Kotlin ORM for JDBC and R2DBC.
 


### PR DESCRIPTION
Signed-off-by: Ola Sæter Heitmann <ola.saeter.heitmann@tietoevry.com>

<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [X] You have read the [contribution guidelines](https://github.com/r2dbc/.github/blob/main/CONTRIBUTING.adoc).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You use the code formatters provided [here](https://github.com/r2dbc/.github/blob/main/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description
Just dug through clients for something work related and realized that this URL was pointing to a version of jOOQ that does not yet seem to support R2DBMS.
Haven't really gone through the trouble of running tests or formatting anything, but I don't really see why this change should cause any issues.
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
